### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/api/proxy.js
+++ b/api/proxy.js
@@ -17,12 +17,20 @@ app.get('/api/proxy.js', async (req, res) => {
         return res.status(400).json({ error: 'Missing query parameter: q' });
     }
 
+    const allowedHostnames = ['example.com', 'searx.be'];
+
     try {
-        let targetUrl = q;
+        let targetUrl;
 
         if (search === 'true') {
             const searxInstance = 'https://searx.be';
             targetUrl = `${searxInstance}/search?q=${encodeURIComponent(q)}`;
+        } else {
+            const url = new URL(q);
+            if (!allowedHostnames.includes(url.hostname)) {
+                return res.status(400).json({ error: 'Invalid hostname' });
+            }
+            targetUrl = url.toString();
         }
 
         const response = await axios.get(targetUrl, {


### PR DESCRIPTION
Potential fix for [https://github.com/Genera1Developer/Curse/security/code-scanning/1](https://github.com/Genera1Developer/Curse/security/code-scanning/1)

To fix the problem, we need to restrict the user input in the URL of the outgoing request. Specifically, we should avoid using user input directly in the hostname of the URL. Instead, we can use an allow-list of known and trusted hostnames. Additionally, we should validate and sanitize the user input to prevent path traversal and other malicious inputs.

1. Create an allow-list of trusted hostnames.
2. Validate the user-provided `q` parameter against the allow-list.
3. Construct the `targetUrl` using the validated hostname and sanitized path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
